### PR TITLE
chore: fix clippy pedantic warnings + refresh wiki test counts

### DIFF
--- a/crates/inference/src/chat_template.rs
+++ b/crates/inference/src/chat_template.rs
@@ -457,7 +457,7 @@ fn strip_llama31_tool_calls(output: &str) -> String {
             let is_tool_call = serde_json::from_str::<serde_json::Value>(json_str)
                 .map(|v| {
                     v["name"].as_str().is_some()
-                        && v.get("parameters").is_some_and(|p| p.is_object())
+                        && v.get("parameters").is_some_and(serde_json::Value::is_object)
                 })
                 .unwrap_or(false);
 

--- a/crates/inference/src/engine.rs
+++ b/crates/inference/src/engine.rs
@@ -59,7 +59,7 @@ impl InferenceEngine {
         })
     }
 
-    /// Override the generation config (temperature, top-p, max_tokens, etc.).
+    /// Override the generation config (temperature, `top-p`, `max_tokens`, etc.).
     pub const fn set_config(&mut self, config: GenerationConfig) {
         self.config = config;
     }

--- a/crates/inference/src/llama_cpp_backend.rs
+++ b/crates/inference/src/llama_cpp_backend.rs
@@ -84,7 +84,7 @@ impl LlamaCppProvider {
         })
     }
 
-    /// Override the generation config (temperature, top-p, max_tokens, etc.).
+    /// Override the generation config (temperature, `top-p`, `max_tokens`, etc.).
     pub const fn set_config(&mut self, config: GenerationConfig) {
         self.config = config;
     }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -16,7 +16,7 @@ const DEFAULT_TIER1_BATCH_SIZE: usize = 10;
 const DEFAULT_TIER2_USAGE_THRESHOLD: f64 = 0.8;
 /// Matches `zipcode_inference::DEFAULT_CONTEXT_SIZE` (Gemma 4's 128K native
 /// window, also the default for `ZIPCODE_LLAMA_SERVER_CTX`). With the prior
-/// 32_768 default, tier-2 was triggering at 26_214 effective tokens — about
+/// `32_768` default, `tier-2` was triggering at `26_214` effective tokens — about
 /// 20 % of the actual window — and evicting tool responses prematurely on
 /// any deployment that didn't manually trim `CompactPolicy`.
 const DEFAULT_CONTEXT_WINDOW_TOKENS: usize = 131_072;

--- a/wiki/GRAPH_REPORT.md
+++ b/wiki/GRAPH_REPORT.md
@@ -1,6 +1,6 @@
 # GRAPH_REPORT — zipcode knowledge graph
 
-Graphify-style summary of the zipcode `crates/` workspace as of 2026-04-28 (provenance anchors refreshed).
+Graphify-style summary of the zipcode `crates/` workspace as of 2026-04-30 (test counts refreshed).
 
 > This report is the "map" view of the wiki: god nodes ranked, surprising cross-crate connections, questions the graph can answer, and a consolidated gotcha list. Community pages live under [`pages/`](pages/).
 
@@ -73,16 +73,16 @@ Drop these into a code search or walk the links — the wiki is pre-wired for th
 
 ---
 
-## Test surface (525+ passing across the workspace)
+## Test surface (1,161 passing + 2 ignored across the workspace)
 
 | Crate | Unit / inline | Integration | Notable |
 |-------|---------------|-------------|---------|
-| `inference` | 251 passing + 1 ignored | 0 separate integration crates | `chat_template.rs` alone carries 20 parsing/formatting robustness tests; `llama_server_backend.rs` has 14 parser/streaming tests; newer tests cover thinking-mode request defaults, `reasoning_content` SSE handling, reasoning/tool-call stream separation, block-array content extraction, and default server options |
-| `tools` | 178 | 0 | Every tool has focused unit coverage; workspace-escape regressions exist for both glob and grep search |
-| `runtime` | 263 unit + 7 doc-tests | 24 (`tests/integration.rs`) | `MockInferenceProvider` drives loop tests including read-only denial, workspace-write approval accept/reject, traversal blocking, persistence, and compaction resume |
+| `inference` | 271 passing + 2 ignored | 7 (`tests/template_integration.rs`) | `chat_template.rs` alone carries 50 parsing/formatting robustness tests; `llama_server_backend.rs` has 109 tests covering parser/streaming, thinking-mode request defaults, `reasoning_content` SSE handling, reasoning/tool-call stream separation, block-array content extraction, and default server options |
+| `tools` | 186 | 52 (`tests/tools_integration.rs`) | Every tool has focused unit coverage; workspace-escape regressions exist for both glob and grep search |
+| `runtime` | 285 (268 lib + 7 `agent_delegation` + 10 `skills`) | 24 (`tests/integration.rs`) + 7 (`tests/compaction.rs`) | `MockInferenceProvider` drives loop tests including read-only denial, workspace-write approval accept/reject, traversal blocking, persistence, and compaction resume |
 | `cli` | 284 unit (in `main.rs` binary) | 45 smoke tests (`tests/smoke.rs`) | Unit tests live across `commands`, `repl`, `render`, `tui`, `tui_composer`, and `width`; smoke tests spawn the real binary in temp `HOME` |
 
-**EXTRACTED** from `cargo test --workspace --release` on 2026-04-28 plus per-file test inventories in the source tree.
+**EXTRACTED** from `cargo test --workspace` on 2026-04-30.
 
 ---
 


### PR DESCRIPTION
## Summary

Three code-quality fixes + wiki accuracy update.

### Code fixes (clippy pedantic)

- **chat_template.rs:460**: Replace redundant closure `|p| p.is_object()` with method reference `serde_json::Value::is_object`
- **engine.rs:62, llama_cpp_backend.rs:87**: Wrap `top-p`, `max_tokens` in backticks in doc comments (clippy::doc_markdown)
- **session.rs:19**: Wrap `tier-2`, `32_768`, `26_214` in backticks in doc comment (clippy::doc_markdown)

Before: 5 pedantic warnings in `cargo clippy --lib -- -W clippy::pedantic`
After: 0 pedantic warnings ✅

### Wiki update (GRAPH_REPORT.md)

The Test surface section was significantly stale:

| Field | Before | After |
|-------|--------|-------|
| Total | 525+ | **1,161 passing + 2 ignored** |
| inference unit | 251 + 1 ignored | 271 + 2 ignored |
| inference integration | 0 | 7 (template_integration) |
| tools unit | 178 | 186 |
| tools integration | 0 | 52 (tools_integration) |
| runtime unit | 263 + 7 doc-tests | 285 (268 lib + 7 agent + 10 skills) |
| runtime integration | 24 | 24 + 7 (compaction) |
| Snapshot date | 2026-04-28 | 2026-04-30 |

## Test plan

- [x] All 1,161 tests pass (`cargo test --workspace`)
- [x] Zero clippy pedantic warnings in lib code (`cargo clippy --lib -- -W clippy::pedantic`)
- [x] Zero clippy all warnings (`cargo clippy --all-targets -- -W clippy::all`)