### PR TITLE
fix(test): eliminate env-var race in server_options tests + clippy fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "gemm"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,10 +2182,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2230,6 +2280,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2350,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -3199,6 +3281,7 @@ dependencies = [
  "dirs",
  "rustyline",
  "serde_json",
+ "serial_test",
  "tempfile",
  "termimad",
  "tokio",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,3 +24,4 @@ unicode-width = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -1141,6 +1141,7 @@ pub const fn help_text() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::time::{SystemTime, UNIX_EPOCH};
     use zipcode_runtime::config::GenerationOverrides;
 
@@ -1710,6 +1711,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_env_overrides_gpu_layers() {
         let config = ZipcodeConfig {
             gpu_layers: Some(10),
@@ -1725,6 +1727,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_env_overrides_flash_attention() {
         let config = ZipcodeConfig {
             flash_attention: false,
@@ -1742,6 +1745,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_env_overrides_context_size() {
         let config = ZipcodeConfig::default();
 
@@ -1753,6 +1757,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_uses_config_context_size_when_no_env() {
         std::env::remove_var("ZIPCODE_LLAMA_SERVER_CTX");
         let config = ZipcodeConfig {
@@ -1768,6 +1773,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_env_beats_config_context_size() {
         let config = ZipcodeConfig {
             context_size: Some(32768),
@@ -1785,6 +1791,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_config_values_when_no_env() {
         // Ensure no leftover env vars
         std::env::remove_var("ZIPCODE_GPU_LAYERS");
@@ -1803,6 +1810,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_env_flash_attention_all_variants() {
         // Test all true-ish values
         for val in &["1", "true", "True", "TRUE"] {
@@ -1826,6 +1834,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn server_options_invalid_env_falls_back_to_config() {
         std::env::set_var("ZIPCODE_GPU_LAYERS", "not_a_number");
         let config = ZipcodeConfig {

--- a/crates/cli/tests/smoke.rs
+++ b/crates/cli/tests/smoke.rs
@@ -79,7 +79,7 @@ fn prepend_path(dir: &std::path::Path) -> String {
 fn write_fake_git(path: &std::path::Path) {
     write_executable(
         path,
-        r##"#!/usr/bin/python3
+        r#"#!/usr/bin/python3
 import os
 import pathlib
 import sys
@@ -109,7 +109,7 @@ if args == ["fetch", "origin"]:
 
 print(f"unexpected fake git invocation: {args}", file=sys.stderr)
 sys.exit(99)
-"##,
+"#,
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #168

8 unit tests in `crates/cli/src/repl.rs` use `std::env::set_var`/`std::env::remove_var` to verify environment variable parsing. When Cargo runs these in parallel, one test can set or remove an env var while another is mid-assertion, causing **intermittent CI failures**.

Additionally, `crates/cli/tests/smoke.rs` has the **only remaining** `clippy::needless_raw_string_hashes` warning.

## Changes

| File | Change |
|------|--------|
| `Cargo.lock` | +serial_test v3.4.0 + transitive deps |
| `crates/cli/Cargo.toml` | +`serial_test = "3"` dev-dependency |
| `crates/cli/src/repl.rs` | +`use serial_test::serial;` + `#[serial]` on 8 env-touching tests |
| `crates/cli/tests/smoke.rs` | `r##"..."##` → `r#"..."#` (clippy fix) |

## Root Cause

`std::env::set_var` mutates **process-global state**. Cargo's default test runner spawns threads, so tests touching the same env vars can race — e.g. `server_options_env_flash_attention_all_variants` sets `ZIPCODE_FLASH_ATTENTION` in a loop while a parallel test clears it.

## Verification

```
✓ cargo clippy --workspace --all-targets -- -W clippy::pedantic -W clippy::nursery  → 0 warnings
✓ cargo test -p zipcode --bin zipcode      → 301 passed
✓ cargo test -p zipcode --test smoke       → 51 passed
✓ cargo test --workspace                   → 1300 passed, 0 failed
```